### PR TITLE
feat: replace preHandler hook with onRequest to define ip property

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function fastifyIp (
       done()
     }
 
-    instance.addHook('preHandler', redefineIpDecorator)
+    instance.addHook('onRequest', redefineIpDecorator)
   } else {
     instance.decorateRequest('ip', ipDecorator)
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -112,7 +112,7 @@ tap.test('Plugin#Decoration', scope => {
 })
 
 tap.test('Plugin#Request IP', scope => {
-  scope.plan(9)
+  scope.plan(10)
 
   scope.test('Should infer the header based on default priority', async t => {
     const app = fastify()
@@ -503,6 +503,28 @@ tap.test('Plugin#Request IP', scope => {
     await app.inject('/withoutPlugin')
     await app.inject({
       path: '/withPlugin',
+      headers: {
+        'x-client-ip': expectedIP
+      }
+    })
+  })
+
+  scope.test('Should set the IP in the "onRequest" hook when trustProxy option is set to true', async t => {
+    const app = fastify({ trustProxy: true })
+    const expectedIP = faker.internet.ip()
+
+    app.register(plugin)
+    app.addHook('onRequest', async (req) => {
+      t.equal(req.ip, expectedIP)
+    })
+    app.get('/', async (req) => {
+      t.equal(req.ip, expectedIP)
+    })
+
+    t.plan(2)
+
+    await app.inject({
+      path: '/',
       headers: {
         'x-client-ip': expectedIP
       }


### PR DESCRIPTION
👋

I modified the hook so that the IP is set in the first phase of the request transformation. This follows the [PR](https://github.com/metcoder95/fastify-ip/pull/51), and I am proposing this change because I have a case where I need to log the IP in an `onRequest` hook (mb, i'm sorry😓).