### PR TITLE
fix: require 'fastify>=5.x'

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const fp = require('fastify-plugin')
 const { inferIPVersion, isIP, isIPv4, isIPv6 } = require('./lib/ip')
 
 const plugin = fp(fastifyIp, {
-  fastify: '>=4.x',
+  fastify: '>=5.x',
   name: 'fastify-ip'
 })
 


### PR DESCRIPTION
Require fastify>=5.x with fastify-plugin so that it can be used with fastify@5